### PR TITLE
Move cleanup-worktrees.sh to claude/ directory and integrate into installation (fix #19)

### DIFF
--- a/claude/cleanup-worktrees.sh
+++ b/claude/cleanup-worktrees.sh
@@ -4,7 +4,7 @@
 # Script to automatically clean up worktrees for closed GitHub issues
 #
 # Usage:
-#   ./scripts/cleanup-worktrees.sh [--dry-run] [--help]
+#   ./claude/cleanup-worktrees.sh [--dry-run] [--help]
 #
 # Options:
 #   --dry-run    Show what would be cleaned up without actually removing anything
@@ -47,7 +47,7 @@ show_help() {
 cleanup-worktrees.sh - Clean up worktrees for closed GitHub issues
 
 USAGE:
-    ./scripts/cleanup-worktrees.sh [OPTIONS]
+    ./claude/cleanup-worktrees.sh [OPTIONS]
 
 OPTIONS:
     --dry-run    Show what would be cleaned up without actually removing anything
@@ -61,10 +61,10 @@ DESCRIPTION:
 
 EXAMPLES:
     # Dry run - see what would be cleaned up
-    ./scripts/cleanup-worktrees.sh --dry-run
+    ./claude/cleanup-worktrees.sh --dry-run
 
     # Actually clean up closed issue worktrees
-    ./scripts/cleanup-worktrees.sh
+    ./claude/cleanup-worktrees.sh
 EOF
 }
 
@@ -302,7 +302,7 @@ main() {
     if [[ "$DRY_RUN" == "true" && $removed_worktrees -gt 0 ]]; then
         echo
         print_info "To actually perform the cleanup, run:"
-        print_info "./scripts/cleanup-worktrees.sh"
+        print_info "./claude/cleanup-worktrees.sh"
     fi
 
     echo "====================================================="

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -91,6 +91,15 @@ else
     log_info ".gitignoreに既にworktree/が存在します"
 fi
 
+# worktreeクリーンアップ実行
+log_info "🧹 worktreeクリーンアップ実行中..."
+if [ -f "./claude/cleanup-worktrees.sh" ]; then
+    ./claude/cleanup-worktrees.sh
+    log_info "✅ worktreeクリーンアップ完了"
+else
+    log_info "⚠️  cleanup-worktrees.sh が見つかりません (スキップ)"
+fi
+
 # worktreeディレクトリの準備
 mkdir -p worktree
 log_info "worktreeディレクトリを作成しました"

--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,7 @@ download_files() {
         "agent-send.sh"
         "setup.sh"
         "local-verification.md"
+        "cleanup-worktrees.sh"
     )
 
     for file in "${files[@]}"; do


### PR DESCRIPTION
## Summary
- Moved cleanup-worktrees.sh from scripts/ to claude/ directory  
- Updated script help text to reflect new path
- Modified install.sh to download cleanup script with proper permissions
- Integrated cleanup execution into setup.sh before worker environment setup
- Removed old scripts directory after migration

## Changes Made

### File Structure Changes
- ✅ Moved scripts/cleanup-worktrees.sh to claude/cleanup-worktrees.sh
- ✅ Updated script internal path references  
- ✅ Removed old script location after migration

### Installation Integration
- ✅ Modified install.sh to download cleanup-worktrees.sh from claude/ directory
- ✅ Ensured proper executable permissions are set on the copied script
- ✅ Added to download list alongside other claude directory contents

### Setup Process Integration  
- ✅ Added cleanup-worktrees.sh execution to setup.sh
- ✅ Cleanup runs before setting up new worker environment
- ✅ Cleanup happens at appropriate point in setup flow

## Benefits
- Centralizes all claude-related scripts in one directory
- Ensures cleanup script is always available after installation  
- Automatic cleanup as part of setup process
- Consistent directory structure

## Test Results
- ✅ Script executes correctly from new location
- ✅ Help text shows correct paths
- ✅ Dry run functionality works as expected
- ✅ Install.sh includes script in download list
- ✅ Setup.sh properly integrates cleanup execution

Closes #19